### PR TITLE
Add keyword resources as suggest and add titles of keywords edges 

### DIFF
--- a/mod_elasticsearch.erl
+++ b/mod_elasticsearch.erl
@@ -91,6 +91,8 @@ search(#search_query{search = {elastic, _Query}} = Search, Context) ->
     elasticsearch_search:search(Search, Context);
 search(#search_query{search = {elastic_suggest, _Query}} = Search, Context) ->
     elasticsearch_search:search(Search, Context);
+search(#search_query{search = {elastic_didyoumean, _Query}} = Search, Context) ->
+    elasticsearch_search:search(Search, Context);
 search(#search_query{search = {query, _Query}} = Search, Context) ->
     Options = #elasticsearch_options{fallback = true},
     elasticsearch_search:search(Search, Options, Context);


### PR DESCRIPTION
This branch adds keyword rsc's to suggest:completion field, weighted on popularity.
It also adds titles of keywords to the keywords field so the general match can handle the suggested keyword title.
It's WIP for solving https://github.com/driebit/mod_elasticsearch/issues/3
and https://github.com/driebit/mod_elasticsearch/issues/12