### PR TITLE
Add fallback to PostgreSQL option

### DIFF
--- a/include/elasticsearch.hrl
+++ b/include/elasticsearch.hrl
@@ -7,3 +7,9 @@
 -record(elasticsearch_fields, {
     query :: binary() | map()
 }).
+
+%% @doc Search options
+%%      fallback: whether to fall back to PostgreSQL for non full-text searches.
+-record(elasticsearch_options, {
+    fallback = true :: boolean()
+}).

--- a/mod_elasticsearch.erl
+++ b/mod_elasticsearch.erl
@@ -22,6 +22,7 @@
 ]).
 
 -include("zotonic.hrl").
+-include("include/elasticsearch.hrl").
 
 -record(state, {context}).
 
@@ -91,7 +92,8 @@ search(#search_query{search = {elastic, _Query}} = Search, Context) ->
 search(#search_query{search = {elastic_suggest, _Query}} = Search, Context) ->
     elasticsearch_search:search(Search, Context);
 search(#search_query{search = {query, _Query}} = Search, Context) ->
-    elasticsearch_search:search(Search, Context);
+    Options = #elasticsearch_options{fallback = true},
+    elasticsearch_search:search(Search, Options, Context);
 search(_Search, _Context) ->
     undefined.
 


### PR DESCRIPTION
This makes sense for simple queries that do no full text searches.