### PR TITLE
Add support for 'has_geo' search

### DIFF
--- a/support/elasticsearch_search.erl
+++ b/support/elasticsearch_search.erl
@@ -650,11 +650,9 @@ map_filter([<<"is_", _/binary>> = Key, Value], _Context) ->
     {true, #{<<"term">> => #{Key => z_convert:to_bool(Value)}}};
 map_filter([Key, exists], _Context) ->
     {true, #{<<"exists">> => #{<<"field">> => Key}}};
-
 %% ne undefined == exists
 map_filter([Key, ne, undefined], Context) ->
     map_filter([Key, exists], Context);
-
 map_filter([Key, Value], _Context) when Value =/= missing ->
     {true, #{<<"term">> => #{Key => z_convert:to_binary(Value)}}};
 map_filter([Key, Value, Options], Context) when is_map(Options) ->

--- a/support/elasticsearch_search.erl
+++ b/support/elasticsearch_search.erl
@@ -331,6 +331,11 @@ map_query(_, _) ->
 -spec map_must_not({atom(), any()}, z:context()) -> {true, list()} | false.
 map_must_not({cat_exclude, []}, _Context) ->
     false;
+
+%% ne undefined is translated into the filter "exists" {"field": Key} in 
+%% the map_filter function
+map_must_not({filter, [_Key, ne, undefined]}, _Context) ->
+    false;
 map_must_not({cat_exclude, Name}, Context) ->
     Cats = parse_categories(Name),
     case filter_categories(Cats, Context) of
@@ -634,12 +639,26 @@ map_filter([[Key | _] | _] = Filters, Context) when is_list(Key); is_binary(Key)
     }}};
 map_filter([Key, Value], Context) when is_list(Key) ->
     map_filter([list_to_binary(Key), Value], Context);
+
 map_filter([<<"pivot_", _/binary>> = Pivot, Value], Context) ->
     map_filter([map_pivot(Pivot), Value], Context);
+
+%% location_lat and location_lng are both mapped to a field 
+%% called geolocation within elasticsearch
+map_filter([<<"location_lat">>, Value], Context) ->
+    map_filter([<<"geolocation">>,  Value], Context);
+map_filter([<<"location_lng">>, Value], Context) ->
+    map_filter([<<"geolocation">>, Value], Context);
+
 map_filter([<<"is_", _/binary>> = Key, Value], _Context) ->
     {true, #{<<"term">> => #{Key => z_convert:to_bool(Value)}}};
 map_filter([Key, exists], _Context) ->
     {true, #{<<"exists">> => #{<<"field">> => Key}}};
+
+%% ne undefined == exists
+map_filter([Key, ne, undefined], Context) ->
+    map_filter([Key, exists], Context);
+
 map_filter([Key, Value], _Context) when Value =/= missing ->
     {true, #{<<"term">> => #{Key => z_convert:to_binary(Value)}}};
 map_filter([Key, Value, Options], Context) when is_map(Options) ->


### PR DESCRIPTION
Ginger supports a 'has_geo=true' filter, which checks wether results
have a location_lng and location_lat field. This commit translates
this filter to something that ElasticSearch understands.