### PR TITLE
Map empty string to null to fix result order

### DIFF
--- a/support/elasticsearch_mapping.erl
+++ b/support/elasticsearch_mapping.erl
@@ -99,6 +99,9 @@ map_value({{_, _, _}, {_, _, _}}) ->
     null;
 map_value(undefined) ->
     null;
+map_value(<<"">>) ->
+    %% Map empty string to null as empty strings interfere with ordering the search results.
+    null;
 map_value(Value) ->
     Value.
 

--- a/tests/mod_elasticsearch_tests.erl
+++ b/tests/mod_elasticsearch_tests.erl
@@ -15,7 +15,7 @@ map_test() ->
     ),
     Mapped = elasticsearch_mapping:map_rsc(Id, context()),
     ?assertEqual(<<"Just a title">>, proplists:get_value(title, Mapped)),
-    ?assertEqual(<<"">>, proplists:get_value(empty_string, Mapped)).
+    ?assertEqual(null, proplists:get_value(empty_string, Mapped)).
 
 context() ->
     z_context:new(testsandboxdb).


### PR DESCRIPTION
* Empty strings interfere with ordering the search results: while
  null values are sorted last by default, empty strings end up in front
  of all results.
* See also https://www.elastic.co/guide/en/elasticsearch/reference/6.3/search-request-sort.html#_missing_values