### PR TITLE
Return maps not proplists

### DIFF
--- a/support/elasticsearch_search.erl
+++ b/support/elasticsearch_search.erl
@@ -491,6 +491,8 @@ map_must(_, _) ->
     false.
 %% TODO: unfinished_or_nodate publication_month
 
+%% @doc Convert a nested proplist to a nested map recursively
+-spec proplist_to_map(list({atom(), term()})) -> #{atom() := term()}.
 proplist_to_map([]) -> #{};
 proplist_to_map([{Key, Value}|Tail]) ->
     Next = proplist_to_map(Tail),

--- a/support/elasticsearch_search.erl
+++ b/support/elasticsearch_search.erl
@@ -80,8 +80,8 @@ search(#search_query{search = {query, Query}, offsetlimit = Offset}, Options, Co
 	    SourceElasticQuery = ElasticQuery#{<<"_source">> => Source},
 	    #search_result{result = Items} = SearchResult =
 		do_search(SourceElasticQuery, ZotonicQuery, Offset, Context),
-	    case Source of 
-		false -> 
+	    case Source of
+		false ->
 		    Ids = [id_to_integer(Item) || Item <- Items],
 		    SearchResult#search_result{result = Ids};
 		_ -> SearchResult
@@ -353,7 +353,7 @@ map_must_not({filter, [Key, Operator, Value]}, Context) when is_list(Key), is_at
 map_must_not({filter, [_Key, Operator, undefined]}, _Context) when Operator =:= '<>'; Operator =:= ne ->
     false;
 map_must_not({filter, [Key, Operator, Value]}, _Context) when Operator =:= '<>'; Operator =:= ne ->
-    {true, #{term => #{Key => z_convert:to_binary(Value)}}};
+    {true, [#{term => #{Key => z_convert:to_binary(Value)}}]};
 map_must_not({filter, [Key, missing]}, _Context) ->
     {true, #{<<"exists">> => #{field => Key}}};
 map_must_not({exclude_document, [Type, Id]}, _Context) ->

--- a/support/elasticsearch_search.erl
+++ b/support/elasticsearch_search.erl
@@ -492,7 +492,7 @@ map_must(_, _) ->
 %% TODO: unfinished_or_nodate publication_month
 
 %% @doc Convert a nested proplist to a nested map recursively
--spec proplist_to_map(list({atom(), term()})) -> #{atom() := term()}.
+-spec proplist_to_map(list({atom(), term()})) -> map().
 proplist_to_map([]) -> #{};
 proplist_to_map([{Key, Value}|Tail]) ->
     Next = proplist_to_map(Tail),


### PR DESCRIPTION
Since we've switched to jiffy instead of jsx for JSON encoding
ES queries, and jsx is more permissive with regards to proplists,
we need to make sure that the zotonic queries contains maps where they
used to have proplists. This commit fixes at least one occurence of this.