### PR TITLE
Add extra clause to `proplist-to-map` function

### DIFF
--- a/support/elasticsearch_search.erl
+++ b/support/elasticsearch_search.erl
@@ -494,6 +494,7 @@ map_must(_, _) ->
 %% @doc Convert a nested proplist to a nested map recursively
 -spec proplist_to_map(list({atom(), term()})) -> map().
 proplist_to_map([]) -> #{};
+proplist_to_map([{}]) -> #{};
 proplist_to_map([{Key, Value}|Tail]) ->
     Next = proplist_to_map(Tail),
     Next#{Key => proplist_to_map(Value)};


### PR DESCRIPTION
Zotonic queries may contain empty proplists (`[{}]`). There was no matching
function clause in the `proplist-to-map`, so I added it.