### PR TITLE
Map Zotonic resources to an Erlang map

### DIFF
--- a/tests/mod_elasticsearch_tests.erl
+++ b/tests/mod_elasticsearch_tests.erl
@@ -9,13 +9,19 @@ map_test() ->
         [
             {category, text},
             {title, <<"Just a title">>},
-            {empty_string, <<"">>}
+            {empty_string, <<"">>},
+            {translated, {trans, [
+                {nl, <<"Apekool">>},
+                {en, <<"Hogwash">>}
+            ]}}
         ],
         z_acl:sudo(context())
     ),
     Mapped = elasticsearch_mapping:map_rsc(Id, context()),
     ?assertEqual(<<"Just a title">>, maps:get(title, Mapped)),
-    ?assertEqual(null, maps:get(empty_string, Mapped)).
+    ?assertEqual(null, maps:get(empty_string, Mapped)),
+    ?assertEqual(<<"Apekool">>, maps:get(<<"translated_nl">>, Mapped)),
+    ?assertEqual(<<"Hogwash">>, maps:get(<<"translated_en">>, Mapped)).
 
 context() ->
     z_context:new(testsandboxdb).

--- a/tests/mod_elasticsearch_tests.erl
+++ b/tests/mod_elasticsearch_tests.erl
@@ -14,8 +14,8 @@ map_test() ->
         z_acl:sudo(context())
     ),
     Mapped = elasticsearch_mapping:map_rsc(Id, context()),
-    ?assertEqual(<<"Just a title">>, proplists:get_value(title, Mapped)),
-    ?assertEqual(null, proplists:get_value(empty_string, Mapped)).
+    ?assertEqual(<<"Just a title">>, maps:get(title, Mapped)),
+    ?assertEqual(null, maps:get(empty_string, Mapped)).
 
 context() ->
     z_context:new(testsandboxdb).


### PR DESCRIPTION
Maps are the universal interface that Erlang JSON libraries take, so
this adds compatibility for alternative JSON libraries (such as Jiffy)
in erlastic_search.