### PR TITLE
Ensure dependencies are started 

### DIFF
--- a/mod_elasticsearch.erl
+++ b/mod_elasticsearch.erl
@@ -64,6 +64,7 @@ manage_schema(_Version, Context) ->
 
     %% When starting mod_elasticsearch for the first time, this function runs
     %% before init/1, so make sure dependencies are started.
+    application:ensure_all_started(erlastic_search),
     start(),
     prepare_index(Context).
 


### PR DESCRIPTION
when mod_elasticsearch is started through schema_migrate call. There was a comment telling us to do so, but no one seemed to have listened... ;)