### PR TITLE
Also return error when no status code is given

### DIFF
--- a/support/elasticsearch.erl
+++ b/support/elasticsearch.erl
@@ -89,7 +89,8 @@ handle_response(Response) ->
             lager:error(
                 "Elasticsearch error: ~p with connection ~p",
                 [Reason, connection()]
-            );
+            ),
+            Response;
         {ok, _} ->
             Response
     end.


### PR DESCRIPTION
These errors occur when ElasticSearch cannot be connected to at all
(and therefore cannot return a status code). For logging and
return messages, we would like to know about this at the call site too.
This fix makes sure that it is returned.