### PR TITLE
docs: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ file:
 [
     %% ...
     {erlastic_search, [
-        {host, <<"elasticsearch">>} %% Defaults to 127.0.0.1
-        {port, 9200}                %% Defaults to 9200
+        {host, <<"elasticsearch">>}, %% Defaults to 127.0.0.1
+        {port, 9200}                 %% Defaults to 9200
     ]},
     %% ...
 ].


### PR DESCRIPTION
Fixes tiny typo in README. Example config is still somewhat misleading