### PR TITLE
Add admin/status button to recreate an empty (resource) index.

### DIFF
--- a/templates/_admin_status.tpl
+++ b/templates/_admin_status.tpl
@@ -1,0 +1,16 @@
+<div class="form-group">
+    <div>
+        {% button class="btn btn-default" text=_"Delete Elastic Search page index"
+            action={confirm text=[
+                                _"Are you sure you want to delete the Elastic Search index?",
+                                "<br><br>",
+                                _"You will need to rebuild the search index to fill it again."
+                            ]
+                            ok=_"Delete"
+                            is_danger
+                            postback={delete_index}
+                            delegate=`mod_elasticsearch`}
+        %}
+        <span class="help-block">{_ Sometimes the Elastic Search index can get out of sync with the database. This will delete and recreate an empty Elastic Search index. _} {_ Use <b>Rebuild search indices</b> to fill the newly created Elastic Search index. _}</span>
+    </div>
+</div>


### PR DESCRIPTION
This adds a button in de admin/status (for admins only) that:

- Drops the current (resource) index
- Recreates the index as an empty index

This is useful for situations where the Elastic index is out of sync with the PostgreSQL database.

See also https://github.com/driebit/mod_elasticsearch2/pull/2