### PR TITLE
Add search notification to enable amending of elastic queries

### DIFF
--- a/include/elasticsearch.hrl
+++ b/include/elasticsearch.hrl
@@ -4,6 +4,10 @@
     id :: binary()
 }).
 
+-record(elasticsearch_query, {
+    index :: binary()
+}).
+
 -record(elasticsearch_fields, {
     query :: binary() | map()
 }).

--- a/support/elasticsearch_search.erl
+++ b/support/elasticsearch_search.erl
@@ -192,11 +192,17 @@ map_score_function(_, _, _) ->
 do_search(ElasticQuery, ZotonicQuery, {From, Size}, Context) ->
     % io:format("~p:~p: ~n~p~n~n", [ ?MODULE, ?LINE, ElasticQuery ]),
     Index = z_convert:to_binary(proplists:get_value(index, ZotonicQuery, elasticsearch:index(Context))),
+    AmendedQuery =
+        z_notifier:foldl(
+          #elasticsearch_query{index = Index}, % should we include From, Size and ZotonicQuery?
+          ElasticQuery,
+          Context
+         ),
 
     %% Invisible by default, as Zotonic has minimum log level 'info'
-    lager:debug("Elasticsearch query on index ~s: ~s", [Index, jsx:encode(ElasticQuery)]),
-    search_result(erlastic_search:search(elasticsearch:connection(),
-                                         Index, ElasticQuery), ElasticQuery, ZotonicQuery, {From, Size}).
+    lager:debug("Elasticsearch query on index ~s: ~s", [Index, jsx:encode(AmendedQuery)]),
+    search_result(erlastic_search:search(elasticsearch:connection(), Index, AmendedQuery),
+                  AmendedQuery, ZotonicQuery, {From, Size}).
 
 %% @doc Process search result
 -spec search_result(tuple(), map(), proplists:proplist(), tuple()) -> any().


### PR DESCRIPTION
Amending is used for automatically adding asciifolded fields (e.g. as `multi_match` converted from `match_phrase`) to queries, in order to be able to find e.g. München when searching for Munchen.